### PR TITLE
Escaping unescaped $

### DIFF
--- a/src/main/g8/test/AppSpec.scala
+++ b/src/main/g8/test/AppSpec.scala
@@ -12,7 +12,7 @@ class AppSpec
 
   describe("/hello/\$name") {
     it("""should respond with "Hello \$name"""") {
-      whenReady(ws.url(s"http://localhost:$port/hello/joe").get()) { r =>
+      whenReady(ws.url(s"http://localhost:\$port/hello/joe").get()) { r =>
         r.body shouldBe "Hello joe"
       }
     }


### PR DESCRIPTION
Fix for $ causing the template to fail to apply